### PR TITLE
Add missing css source maps to build

### DIFF
--- a/.wvr/build-config.js
+++ b/.wvr/build-config.js
@@ -61,12 +61,20 @@ const config = {
       to: './views'
     },
     {
-      from: './node_modules/ng-table/bundles/ng-table.css',
-      to: './resources/styles/ng-table/bundles/ng-table.css',
+      from: './node_modules/ng-table/bundles/ng-table.min.css',
+      to: './resources/styles/ng-table/bundles/ng-table.min.css',
     },
     {
-      from: './node_modules/bootstrap/dist/css/bootstrap.css',
-      to: './resources/styles/bootstrap/dist/css/bootstrap.css',
+      from: './node_modules/ng-table/bundles/ng-table.min.css.map',
+      to: './resources/styles/ng-table/bundles/ng-table.min.css.map',
+    },
+    {
+      from: './node_modules/bootstrap/dist/css/bootstrap.min.css',
+      to: './resources/styles/bootstrap/dist/css/bootstrap.min.css',
+    },
+    {
+      from: './node_modules/bootstrap/dist/css/bootstrap.min.css.map',
+      to: './resources/styles/bootstrap/dist/css/bootstrap.min.css.map',
     },
   ],
   entry: {

--- a/app/index.html
+++ b/app/index.html
@@ -18,8 +18,8 @@
 
   <link rel="shortcut icon" href="resources/images/favicon.ico" type="image/x-icon">
 
-  <link rel="stylesheet" type='text/css' href="resources/styles/ng-table/bundles/ng-table.css">
-  <link rel="stylesheet" type='text/css' href="resources/styles/bootstrap/dist/css/bootstrap.css">
+  <link rel="stylesheet" type='text/css' href="resources/styles/ng-table/bundles/ng-table.min.css">
+  <link rel="stylesheet" type='text/css' href="resources/styles/bootstrap/dist/css/bootstrap.min.css">
   <link rel="stylesheet" type='text/css' href="resources/styles/app.css">
 
   <link rel="stylesheet" type="text/css" href="//labs.library.tamu.edu/tl-components/2x/styles.css">


### PR DESCRIPTION
# Description

Adds missing css source maps to build in .wvr/build-config.js

Fixes #214 

# How Has This Been Tested?

Deployed to dev with no warnings in log. https://labs.library.tamu.edu/magpie/

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

