### PR TITLE
Added the Lato font link to head section and rem rule to css file

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -18,6 +18,8 @@
 
   <link rel="shortcut icon" href="resources/images/favicon.ico" type="image/x-icon">
 
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700' rel='stylesheet' type='text/css'>
+
   <link rel="stylesheet" type='text/css' href="resources/styles/ng-table/bundles/ng-table.min.css">
   <link rel="stylesheet" type='text/css' href="resources/styles/bootstrap/dist/css/bootstrap.min.css">
   <link rel="stylesheet" type='text/css' href="resources/styles/app.css">

--- a/app/resources/styles/sass/app.scss
+++ b/app/resources/styles/sass/app.scss
@@ -6,6 +6,14 @@ $linkColor: #337ab7;
 @import "node_modules/@wvr/core/app/resources/styles/sass/main";
 @import "node_modules/@wvr/core/app/resources/styles/sass/theme-base";
 
+html {
+  font-size: 1rem;
+}
+
+body {
+  font-family: "Lato", sans-serif;
+}
+
 main {
   display: block;
   height: auto;


### PR DESCRIPTION
# Description
inconsistent sizing from bootstrap classes between SAGE and the Library main site. This is due to Bootstraps use of the rem unit, and SAGE's lack of font-size definition at the HTML element level.
The absence of the Lato font.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Confirmed using Inspector Tools
- [ ] Visual Confirmation

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

