### PR TITLE
Overriding the z-index rule for button on active or hover for paginat…

### DIFF
--- a/app/resources/styles/sass/app.scss
+++ b/app/resources/styles/sass/app.scss
@@ -320,3 +320,13 @@ content-viewer {
     }
   }
 }
+
+.btn-group-vertical>.btn.active,
+.btn-group-vertical>.btn:active,
+.btn-group-vertical>.btn:focus,
+.btn-group-vertical>.btn:hover,
+.btn-group>.btn.active,
+.btn-group>.btn:focus,
+.btn-group>.btn:hover {
+  z-index: 0;
+}

--- a/app/resources/styles/sass/app.scss
+++ b/app/resources/styles/sass/app.scss
@@ -327,6 +327,12 @@ content-viewer {
 .btn-group-vertical>.btn:hover,
 .btn-group>.btn.active,
 .btn-group>.btn:focus,
-.btn-group>.btn:hover {
+.btn-group>.btn:hover,
+.pagination>.active>a,
+.pagination>.active>a:focus,
+.pagination>.active>a:hover,
+.pagination>.active>span,
+.pagination>.active>span:focus,
+.pagination>.active>span:hover {
   z-index: 0;
 }


### PR DESCRIPTION

# Description

While choosing the page limit ( eg 100 ) and scrolling down to the bottom - we can see that the active button has a z-index present in its property ( z-index: 2; )

Fixes [#8](https://github.com/TAMULib/MAGPIE/issues/8)

## Type of change

Please delete options that are not relevant.
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Visual Confirmation
- [X] Checked using the Inspector Tools to ensure style was overriding the bootstrap (button) style

**Test Configuration**:
* Toolchain:
* SDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

