### PR TITLE
Enforce line-feed/new-line character as the only EOL for certain line-ending sensitive script files.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+build/docker-entrypoint.sh text eol=lf
+build/docker-npmrc.sh text eol=lf


### PR DESCRIPTION
This problem happens when starting a Docker container that attempts to run these files. The line-endings could end up with carriage-return characters and the scripts may fail to execute.

References:
- https://git-scm.com/docs/git-config#Documentation/git-config.txt-coreattributesFile
- https://git-scm.com/docs/gitattributes
- https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings